### PR TITLE
UserForms 4.x Compatibility

### DIFF
--- a/code/EditableMailchimpSubscribeField.php
+++ b/code/EditableMailchimpSubscribeField.php
@@ -27,17 +27,24 @@ class EditableMailchimpSubscribeField extends EditableFormField
     /**
      * @return FieldList
      */
-    public function getFieldConfiguration()
+    public function getCMSFields()
     {
         $listID = $this->getSetting('ListID');
 
-        /** @var Form $parent */
-        $parent = $this->Parent();
+        /** @var DataList $otherFields */
+        $otherFields = EditableFormField::get()->filter(
+            array(
+                'ParentID' => $this->Parent()->ID,
+                'ID:not' => $this->ID,
+                'ClassName:not' => array(
+                    'EditableFormStep',
+                    'EditableFieldGroup',
+                    'EditableFieldGroupEnd',
+                )
+            )
+        );
 
-        /** @var HasManyList $otherFields */
-        $otherFields = $parent->Fields();
-
-        $otherFields = $otherFields->map('Name', 'Title')->toArray();
+        $otherFields = $otherFields->map('Name', 'Title');
 
         $emailField = $this->getSetting('EmailField');
         $firstNameField = $this->getSetting('FirstNameField');

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
   "type"       : "silverstripe-module",
   "require"    : {
     "silverstripe/cms"      : "~3.1",
+    "silverstripe/userforms": "~4",
     "pacely/mailchimp-apiv3": "~1.0.3"
   },
   "license"    : "MIT",


### PR DESCRIPTION
4.x has introduced some breaking changes which this PR remedies, thus `silverstripe/userforms` constraint has been increased to `~4` .

Should a user require userforms-3.x compatibility they should use the [V1.1.2 Release](https://github.com/webfox/silverstripe-userforms-mailchimp/releases/tag/v1.1.2)