### PR TITLE
PHP constraint is 5.4 minimum

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
   ],
   "type"       : "silverstripe-module",
   "require"    : {
+    "php": ">=5.4",
     "silverstripe/userforms": "~3",
     "silverstripe/cms"      : "~3.1",
     "silverstripe/userforms": "~4",


### PR DESCRIPTION
Due to a dependencies use of the short array syntax `['key' => 'value']` instead of `array('key' => 'value')`